### PR TITLE
fix: completely validate the plugin by loading schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         kongVersion:
-        - "3.2.x"
+        - "3.3.x"
 
     steps:
     - uses: actions/checkout@v3

--- a/kong-plugin-konnect-plugin-schema-validation-0.1.0-1.rockspec
+++ b/kong-plugin-konnect-plugin-schema-validation-0.1.0-1.rockspec
@@ -18,7 +18,7 @@ source = {
 
 
 description = {
-  summary = "Konnect Plugin Schema Validation provides an access handle to validate plugin schemas.",
+  summary = "Konnect Plugin Schema Validation provides an access handler to validate a plugin schema.",
   homepage = "https://"..github_account_name..".github.io/"..github_repo_name,
   license = "Apache 2.0",
 }


### PR DESCRIPTION
This fix ensures that the plugin schema is loaded for extra validation of the schema. Typos and missing returns are also part of this fix.