### PR TITLE
fix: correct use of pcall methods

### DIFF
--- a/kong/plugins/konnect-plugin-schema-validation/handler.lua
+++ b/kong/plugins/konnect-plugin-schema-validation/handler.lua
@@ -60,11 +60,11 @@ local function validate_plugin_schema(input)
     local err
     plugin_schema, err = load(input)()
     if err then
-      return nil, nil, "error processing load for plugin schema: " .. err
+      return error("error processing load for plugin schema: " .. err)
     end
   end)
   if not pok then
-    return nil, nil, "error processing load for plugin schema: " .. perr
+    return nil, nil, perr
   end
   if is_empty(plugin_schema) then
     return nil, nil, "invalid schema for plugin: cannot be empty"
@@ -78,11 +78,11 @@ local function validate_plugin_schema(input)
   local pok, perr = pcall(function()
     local ok, err = metaschema.MetaSubSchema:validate(plugin_schema)
     if not ok then
-      return nil, nil, tostring(errors:schema_violation(err))
+      return error(errors:schema_violation(err))
     end
   end)
   if not pok then
-    return nil, nil, "error calling MetaSubSchema:validate: " .. perr
+    return nil, nil, perr
   end
 
   -- Load the plugin schema for use in configuration validation when
@@ -92,20 +92,17 @@ local function validate_plugin_schema(input)
     return nil, nil, "unable to create plugin entity: " .. err
   end
   local plugin_name = plugin_schema.name
-  if is_empty(plugin_name) then
-    return nil, nil, "invalid schema for plugin: missing plugin name"
-  end
   -- Note: "pcall" is used for this operation to ensure proper error handling
   -- for "assert" calls performed in the "entity:new_subschema" function. When
   -- iterating the arrays/fields of the plugin schema an "assert" is possible.
   pok, perr = pcall(function()
     local ok, err = plugins_subschema_entity:new_subschema(plugin_name, plugin_schema)
     if not ok then
-      return nil, nil, "error loading schema for plugin " .. plugin_name .. ": " .. err
+      return error("error loading schema for plugin " .. plugin_name .. ": " .. err)
     end
   end)
   if not pok then
-    return nil, nil, "error validating plugin schema: " .. perr
+    return nil, nil, perr
   end
 
   return plugins_subschema_entity, plugin_schema, nil
@@ -133,7 +130,19 @@ function konnect_plugin_schema_validation:access(conf)
   end
   local _, plugin_schema, err = validate_plugin_schema(body.schema)
   if err then
-    return kong.response.error(400, err) -- Bad request
+    -- Handle error messages that already that are already formatted
+    if type(err) == "string" then
+      return kong.response.error(400, err) -- Bad request
+    end
+
+    -- Remove extra fields if message is present
+    local rmessage = err
+    if err.message then
+      rmessage = {
+        message = err.message
+      }
+    end
+    return kong.response.exit(400, rmessage, { ["Content-Type"] = "application/json" }) -- Bad request
   end
   if plugin_schema == nil then
     return kong.response.error(500, "validated plugin_schema is empty")

--- a/spec/konnect-plugin-schema-validation/02-integration_spec.lua
+++ b/spec/konnect-plugin-schema-validation/02-integration_spec.lua
@@ -1,6 +1,8 @@
 local helpers = require "spec.helpers"
 local PLUGIN_NAME = "konnect-plugin-schema-validation"
 
+local pl_stringx = require "pl.stringx"
+
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
     local client
@@ -110,7 +112,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
           assert.response(r).has.status(400)
           local json = assert.response(r).has.jsonbody()
           assert.same({
-            message = "invalid schema for plugin: missing plugin name"
+            message = "schema violation (name: field required for entity check)"
           }, json)
         end)
 
@@ -165,6 +167,27 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
           assert.same({
             message = "invalid schema for plugin: cannot be empty"
           }, json)
+        end)
+
+        it("fails when type definition is not one of expected types", function()
+          local r = client:post("/konnect/plugin/schema/validation", {
+            headers = {
+              ["Content-Type"] = "application/json"
+            },
+            body = {
+              schema = [[
+                return {
+                  name = "invalid-type-foo",
+                  fields = {
+                    { config = { type = "foo", fields = {} } }
+                  }
+                }
+              ]]
+            }
+          })
+          assert.response(r).has.status(400)
+          local json = assert.response(r).has.jsonbody()
+          assert.truthy(pl_stringx.startswith(json.message, 'schema violation (fields.1: {\n  type = \"expected one of:'))
         end)
       end)
     end)


### PR DESCRIPTION
This fix corrects an issue where invalid schema could be returned as OK; however the error was being lost within a pcall method due to improper usage.